### PR TITLE
Rearchitect and use test/unit

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,21 +41,21 @@ require 'docopt'
 
 
 if __FILE__ == $0
-    options = docopt(doc, '1.0.0')  # parse options based on doc above
+    options = Docopt(doc, '1.0.0')  # parse options based on doc above
     puts options.inspect
     puts ARGV.inspect
 end
 ```
 
 Hell yeah! The option parser is generated based on `doc` string above, that you
-pass to the `docopt` function.
+pass to the `Docopt` function.
 
 API `require 'docopt'`
 ===============================================================================
 
-###`options = docopt(doc, version=nil, help=true)`
+###`options = Docopt(doc, version=nil, help=true)`
 
-`docopt` takes 1 required and 2 optional arguments:
+`Docopt` takes 1 required and 2 optional arguments:
 
 - `doc` should be a string that
 describes **options** in a human-readable format, that will be parsed to create
@@ -93,7 +93,7 @@ doc = "Options:
   --verbose
   -o FILE  Output file [default: out.txt]"
   
-options = docopt(doc)
+options = Docopt(doc)
 
 puts options.inspect
 # --verbose=nil
@@ -107,7 +107,7 @@ doc = "Options:
   -v, --verbose  Verbose output [default: true]
   -o FILE  Output file [default: out.txt]"
   
-options = docopt(doc)
+options = Docopt(doc)
 
 # The following are equivilant:
 

--- a/docopt.rb
+++ b/docopt.rb
@@ -96,7 +96,7 @@ class Docopt
 end
 
 # Convenience method for Docopt.parse
-def docopt *args
+def Docopt *args
   Docopt.new *args
 end
 
@@ -108,7 +108,7 @@ if __FILE__ == $0
     def setup
       $LOAD_PATH << File.dirname(__FILE__)
       load 'example.rb'
-      @docopt = docopt($DOC)
+      @docopt = Docopt($DOC)
     end
     
     def test_size

--- a/example.rb
+++ b/example.rb
@@ -24,7 +24,7 @@ require 'docopt'
 
 
 if __FILE__ == $0
-    options = docopt($DOC, '1.0.0')  # parse options based on doc above
+    options = Docopt($DOC, '1.0.0')  # parse options based on doc above
     puts options.inspect
     puts ARGV.inspect
 end


### PR DESCRIPTION
So, quite a major refactor here, this is still api-compatible but with a simpler structure.

The main changes are:

1) Make `docopt` a convenience method that returns a new instance of the `Docopt` class
2) Remove `option` method and place logic inside initalize method of `Option` class. This makes the class less of a 'dumb container' and instead knows how to intialize itself from an option line
3) Namespace `Option` class to `Docopt::Option`
4) Add `Docopt::UnknownOptionError` custom exception class
5) Refactor tests to use ruby's built in `test/unit` functionality.
6) Add tests for `Docopt` class
7) Add ability to access argument values by short or long name if both valid, along with allowing access by symbols also

Quite a lot at once but the changes were quite interdependent, let me know what you think!
