### PR TITLE
Convert params hash to symbols prior to merging.

### DIFF
--- a/lib/docopt.rb
+++ b/lib/docopt.rb
@@ -635,7 +635,7 @@ module Docopt
 
     def docopt(doc, params={})
       default = {:version => nil, :argv => nil, :help => true}
-      params = default.merge(params)
+      params = default.merge(params.inject({}){|tmp,(k,v)| tmp[k.to_sym] = v; tmp})
       params[:argv] = ARGV if !params[:argv]
 
       Exit.set_usage(printable_usage(doc))


### PR DESCRIPTION
Fixes #19:

``` ruby
[1] pry(main)> default = {:version => nil, :argv => nil, :help => true}
=> {:version=>nil, :argv=>nil, :help=>true}
[2] pry(main)> params = {'version' => '1.0.0'}
=> {"version"=>"1.0.0"}
[3] pry(main)> params = default.merge(params.inject({}){|tmp,(k,v)| tmp[k.to_sym] = v; tmp})
=> {:version=>"1.0.0", :argv=>nil, :help=>true}
```
