### PR TITLE
Fix Shadow warnings

### DIFF
--- a/lib/docopt.rb
+++ b/lib/docopt.rb
@@ -356,9 +356,9 @@ module Docopt
       collected ||= []
       outcomes = []
       for p in self.children
-        matched, _, _ = outcome = p.match(left, collected)
+        matched, _, _ = found = p.match(left, collected)
         if matched
-          outcomes << outcome
+          outcomes << found
         end
       end
 

--- a/lib/docopt.rb
+++ b/lib/docopt.rb
@@ -86,31 +86,31 @@ module Docopt
       groups = [[self]]
       while groups.count > 0
         children = groups.shift
-        types = children.map { |c| c.class }
+        types = children.map { |child| child.class }
 
         if types.include?(Either)
-          either = children.select { |c| c.class == Either }[0]
+          either = children.select { |child| child.class == Either }[0]
           children.slice!(children.index(either))
           for c in either.children
             groups << [c] + children
           end
         elsif types.include?(Required)
-          required = children.select { |c| c.class == Required }[0]
+          required = children.select { |child| child.class == Required }[0]
           children.slice!(children.index(required))
           groups << required.children + children
 
         elsif types.include?(Optional)
-          optional = children.select { |c| c.class == Optional }[0]
+          optional = children.select { |child| child.class == Optional }[0]
           children.slice!(children.index(optional))
           groups << optional.children + children
 
         elsif types.include?(AnyOptions)
-          anyoptions = children.select { |c| c.class == AnyOptions }[0]
+          anyoptions = children.select { |child| child.class == AnyOptions }[0]
           children.slice!(children.index(anyoptions))
           groups << anyoptions.children + children
 
         elsif types.include?(OneOrMore)
-          oneormore = children.select { |c| c.class == OneOrMore }[0]
+          oneormore = children.select { |child| child.class == OneOrMore }[0]
           children.slice!(children.index(oneormore))
           groups << (oneormore.children * 2) + children
 

--- a/lib/docopt.rb
+++ b/lib/docopt.rb
@@ -314,7 +314,7 @@ module Docopt
     def match(left, collected=nil)
       collected ||= []
       for p in self.children
-        m, left, collected = p.match(left, collected)
+        _, left, collected = p.match(left, collected)
       end
       return [true, left, collected]
     end


### PR DESCRIPTION
A really basic patch to get rid of some pesky warnings. Nothing complicated or involved.

- Rename the proc arg `c` to `child` (a more explicit name in my opinion!) in `either`
- Rename `outcome` to `found` in a `match`.
- Underscore out the `m` variable in a `match` 

Passes tests.

CC @DannyBen

Close #21 
  