### PR TITLE
Add Docopt::Exit#error? to infer exit status

### DIFF
--- a/lib/docopt.rb
+++ b/lib/docopt.rb
@@ -18,8 +18,13 @@ module Docopt
       @@message
     end
 
-    def initialize(message='')
+    def initialize(message='', error=true)
       @@message = (message + "\n" + @@usage).strip
+      @error = error
+    end
+
+    def error?
+      !!@error
     end
   end
 
@@ -634,11 +639,11 @@ module Docopt
     def extras(help, version, options, doc)
       if help and options.any? { |o| ['-h', '--help'].include?(o.name) && o.value }
         Exit.set_usage(nil)
-        raise Exit, doc.strip
+        raise Exit.new(doc.strip, false)
       end
       if version and options.any? { |o| o.name == '--version' && o.value }
         Exit.set_usage(nil)
-        raise Exit, version
+        raise Exit.new(version, false)
       end
     end
 

--- a/test/test_docopt.rb
+++ b/test/test_docopt.rb
@@ -1,5 +1,6 @@
 require 'test/unit'
 require 'pathname'
+require 'docopt'
 
 class DocoptTest < Test::Unit::TestCase
 
@@ -8,5 +9,29 @@ class DocoptTest < Test::Unit::TestCase
   def test_docopt_reference_testcases
     puts
     assert system('python', "test/language_agnostic_tester.py", "test/testee.rb", chdir: TOPDIR)
+  end
+
+  def test_exit_success_on_help
+    exception = assert_raises(Docopt::Exit) do
+      Docopt.docopt("Usage: mytool -a", :argv => ["--help"])
+    end
+
+    assert !exception.error?
+  end
+
+  def test_exit_success_on_version
+    exception = assert_raises(Docopt::Exit) do
+      Docopt.docopt("Usage: mytool -a", :version => "1.2.3", :argv => ["--version"])
+    end
+
+    assert !exception.error?
+  end
+
+  def test_exit_failure_on_unknown_option
+    exception = assert_raises(Docopt::Exit) do
+      Docopt.docopt("Usage: mytool -a", :argv => ["--foo"])
+    end
+
+    assert exception.error?
   end
 end


### PR DESCRIPTION
Addresses https://github.com/docopt/docopt.rb/issues/18. This project appears to be unmaintained, but I figured this changeset could be useful for others even if it doesn't get merged.